### PR TITLE
Perform single copy + pointer select instead of double write for small types

### DIFF
--- a/src/quicksort.rs
+++ b/src/quicksort.rs
@@ -254,11 +254,6 @@ where
 
 /// Specialization for small types, through traits to not invoke compile time
 /// penalties for loop unrolling when not used.
-///
-/// Benchmarks show that for small types simply storing to *both* potential
-/// destinations is more efficient than a conditional store. It is also less at
-/// risk of having the compiler generating a branch instead of conditional
-/// store. And explicit loop unrolling is also often very beneficial.
 impl<T> StablePartitionTypeImpl for T
 where
     T: Copy + crate::Freeze,
@@ -280,13 +275,8 @@ where
         }
 
         unsafe {
-            // SAFETY: exactly the same invariants and logic as the
-            // non-specialized impl. The conditional store being replaced by a
-            // double copy changes nothing, on all but the final iteration the
-            // bad write will simply be overwritten by a later iteration, and on
-            // the final iteration we write to the same index twice. And we do
-            // naive loop unrolling where the exact same loop body is just
-            // repeated.
+            // SAFETY: exactly the same invariants and logic as the non-specialized impl. And we do
+            // naive loop unrolling where the exact same loop body is just repeated.
             let pivot = v_base.add(pivot_pos);
 
             let mut loop_body = |state: &mut PartitionState<T>| {


### PR DESCRIPTION
A previous optimization is no longer deemed worth it, new test results and understanding suggest that a single call to ptr::copy_nonoverlapping per element is more efficient for large input that don't fit into the last level cache. As well as for types like f128.

```
rustc 1.76.0-nightly (4cb3beec8 2023-11-18)
```

Zen 3 results

![image](https://github.com/Voultapher/driftsort/assets/6864584/d36f70bb-487d-4357-980f-e208cb957ed9)

![image](https://github.com/Voultapher/driftsort/assets/6864584/82dd27b5-78fe-4078-9347-029d283097dc)

![image](https://github.com/Voultapher/driftsort/assets/6864584/5b6756ee-e71d-4d7e-84c3-41aa6fd2bd28)

Firestorm results:

![image](https://github.com/Voultapher/driftsort/assets/6864584/bec80455-88ac-43cd-82d0-5dd98d42a92b)

![image](https://github.com/Voultapher/driftsort/assets/6864584/c629fc91-7fa3-43ed-bfe7-38d3daed1817)

![image](https://github.com/Voultapher/driftsort/assets/6864584/2475129f-cdb4-4853-99e7-98521a7579dc)

Icestorm results, honestly those look quite wonky, not sure if they should be trusted

![image](https://github.com/Voultapher/driftsort/assets/6864584/803bdf8f-b860-4b19-bed8-aed063280962)

![image](https://github.com/Voultapher/driftsort/assets/6864584/8b61bf4e-1e64-45a8-a8cf-24f12807d241)

![image](https://github.com/Voultapher/driftsort/assets/6864584/4973d6d7-a700-4bfe-abac-7b0541715155)
