### PR TITLE
Remove small-sort size threshold

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(incomplete_features)]
+#![allow(incomplete_features, internal_features)]
 #![feature(
     ptr_sub_ptr,
     maybe_uninit_slice,

--- a/src/smallsort.rs
+++ b/src/smallsort.rs
@@ -41,7 +41,6 @@ pub const MIN_SMALL_SORT_SCRATCH_LEN: usize = i32::SMALL_SORT_THRESHOLD + 16;
 impl<T> SmallSortTypeImpl for T
 where
     T: crate::Freeze,
-    (): crate::IsTrue<{ mem::size_of::<T>() <= 96 }>,
 {
     const SMALL_SORT_THRESHOLD: usize = 20;
 


### PR DESCRIPTION
The original reasons for adding this, did not hold up to closer scrutiny. As discussed out-of-band.