### PR TITLE
Generalize bidirectional merge in smallsort to non-even lengths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,3 @@ const fn has_direct_interior_mutability<T>() -> bool {
     // could lead to double free.
     !T::IS_FREEZE
 }
-
-trait IsTrue<const B: bool> {}
-impl IsTrue<true> for () {}


### PR DESCRIPTION
I didn't notice significant performance changes on Apple M1, but I still prefer this as it eliminates an extra call to insertion sort for odd lengths. I also fixed/added some comments.